### PR TITLE
Add BlueIris profile monitoring and Fix Bytes format 

### DIFF
--- a/blueiris/blueirisMetrics.go
+++ b/blueiris/blueirisMetrics.go
@@ -270,25 +270,26 @@ func convertStrFloat(s string) (f float64, err error) {
 	}
 }
 
-func convertBytes(s string) (f float64, err error) {
+func convertBytes(s string, unit string) (f float64, err error) {
 	var bytefl float64
 	var errConv error
 	var convertedFloat float64
-	if strings.HasSuffix(s, "B") {
-		bytefl, errConv = convertStrFloat(strings.Replace(s, "B", "", 1))
-	} else if strings.HasSuffix(s, "K") {
-		convertedFloat, errConv = convertStrFloat(strings.Replace(s, "K", "", 1))
+	if strings.Compare(unit, "B") == 0 {
+		bytefl, errConv = convertStrFloat(s)
+	} else if strings.Compare(unit, "KB") == 0 || strings.Compare(unit, "K") == 0 {
+		convertedFloat, errConv = convertStrFloat(s)
 		bytefl = convertedFloat * 1024
-	} else if strings.HasSuffix(s, "M") {
-		convertedFloat, errConv = convertStrFloat(strings.Replace(s, "M", "", 1))
+	} else if strings.Compare(unit, "MB") == 0 || strings.Compare(unit, "M") == 0 {
+		convertedFloat, errConv = convertStrFloat(s)
 		bytefl = convertedFloat * 1024 * 1024
-	} else if strings.HasSuffix(s, "G") {
-		convertedFloat, errConv = convertStrFloat(strings.Replace(s, "G", "", 1))
+	} else if strings.Compare(unit, "GB") == 0 || strings.Compare(unit, "G") == 0 {
+		convertedFloat, errConv = convertStrFloat(s)
 		bytefl = convertedFloat * 1024 * 1024 * 1024
-	} else if strings.HasSuffix(s, "T") {
-		convertedFloat, errConv = convertStrFloat(strings.Replace(s, "T", "", 1))
+	} else if strings.Compare(unit, "TB") == 0 || strings.Compare(unit, "T") == 0 {
+		convertedFloat, errConv = convertStrFloat(s)
 		bytefl = convertedFloat * 1024 * 1024 * 1024 * 1024
 	} else {
+		common.BIlogger(fmt.Sprintf("s %s , Unit %s", s,unit), "console")
 		errConv = errors.New("unable to determine sting type (B, K, M, G, T)")
 	}
 	return bytefl, errConv
@@ -392,10 +393,10 @@ func findObject(line string) (match []string, r *regexp.Regexp, matchType string
 			camerastatus[camera]["detail"] = status
 		}
 	} else if strings.Contains(line, "Delete: ") && strings.HasPrefix(line, "0 ") {
-		r := regexp.MustCompile(`(?P<folder>[^\s\\]*)(\s*Delete:).+(\[(((?P<hoursused>[0-9]*)\/(?P<hourstotal>[0-9]*))\shrs,(\s(?P<sizeused>.+)\/(?P<sizelimit>.+)),\s(?P<diskfree>.+)\sfree)\])`)
+		r := regexp.MustCompile(`(?P<folder>[^\s\\]*)(\s*Delete:).+(\[(((?P<hoursused>[0-9]*)\/(?P<hourstotal>[0-9]*))\shrs,(\s(?P<sizeused>[\d\.]+)(?P<sizeunit>\w*)\/(?P<sizelimit>[\d\.]+)(?P<sizelimitunit>\w+)),\s((?P<diskfree>[\d\.]+)(?P<freeunit>\w+))\sfree)\])`)
 		match := r.FindStringSubmatch(line)
 		if len(match) == 0 {
-			r1 := regexp.MustCompile(`(?P<folder>[^\s\\]*)(\s*Delete:).+(\[((?P<sizeused>.+)\/(?P<sizelimit>.+)),\s(?P<diskfree>.+)\sfree\])`)
+			r1 := regexp.MustCompile(`(?P<folder>[^\s\\]*)(\s*Delete:).+(\[((\s(?P<sizeused>[\d\.]+)(?P<sizeunit>\w*)\/(?P<sizelimit>[\d\.]+)(?P<sizelimitunit>\w+)),\s((?P<diskfree>[\d\.]+)(?P<freeunit>\w+))\sfree\])`)
 			match1 := r1.FindStringSubmatch(line)
 			if len(match1) == 0 {
 				parseErrors = appendCounterMap(parseErrors, line)
@@ -406,32 +407,48 @@ func findObject(line string) (match []string, r *regexp.Regexp, matchType string
 			sizeusedMatch1 := r1.SubexpIndex("sizeused")
 			sizelimitMatch1 := r1.SubexpIndex("sizelimit")
 			diskfreeMatch1 := r1.SubexpIndex("diskfree")
+			sizeunitMatch1 := r1.SubexpIndex("sizeunit")
+			sizelimitunitMatch1 := r1.SubexpIndex("sizelimitunit")
+			freeunitMatch1 := r1.SubexpIndex("freeunit")
 
 			folder1 := match1[folderMatch1]
-			sizeused1, err := convertBytes(match1[sizeusedMatch1])
-			if err != nil {
-				common.BIlogger(fmt.Sprintf("Unable to get convert sizeused Error: \n%v", err), "console")
-				return nil, nil, ""
-			}
-			sizelimit1, err := convertBytes(match1[sizelimitMatch1])
+			
+			sizelimit1, err := convertBytes(match1[sizelimitMatch1],match1[sizelimitunitMatch1])
 			if err != nil {
 				common.BIlogger(fmt.Sprintf("Unable to get convert sizelimit Error: \n%v", err), "console")
 				return nil, nil, ""
 			}
-			diskfree1, err := convertBytes(match1[diskfreeMatch1])
+			diskfree1, err := convertBytes(match1[diskfreeMatch1],match1[freeunitMatch1])
 			if err != nil {
 				common.BIlogger(fmt.Sprintf("Unable to get convert diskfree Error: \n%v", err), "console")
 				return nil, nil, ""
 			}
-
-			sizePercent1 := (sizeused1 / sizelimit1) * 100
-
-			if _, ok := diskStats[folder1]; !ok {
-				diskStats[folder1] = make(map[string]float64)
-			}
-
-			diskStats[folder1]["diskfree"] = diskfree1
-			diskStats[folder1]["sizePercent"] = sizePercent1
+			
+			if strings.Compare(match1[sizeunitMatch1],"") == 0 {
+				sizeused1, err := convertBytes(match[sizeusedMatch1],match1[sizelimitunitMatch1])
+				if err != nil {
+					common.BIlogger(fmt.Sprintf("Unable to get convert sizeused Error: \n%v", err), "console")
+					return nil, nil, ""
+				}
+				sizePercent1 := (sizeused1 / sizelimit1) * 100
+				if _, ok := diskStats[folder1]; !ok {
+					diskStats[folder1] = make(map[string]float64)
+				}
+				diskStats[folder1]["diskfree"] = diskfree1
+				diskStats[folder1]["sizePercent"] = sizePercent1
+			} else {
+				sizeused1, err := convertBytes(match[sizeusedMatch1], match1[sizeunitMatch1])
+				if err != nil {
+					common.BIlogger(fmt.Sprintf("Unable to get convert sizeused Error: \n%v", err), "console")
+					return nil, nil, ""
+				}
+				sizePercent1 := (sizeused1 / sizelimit1) * 100
+				if _, ok := diskStats[folder1]; !ok {
+					diskStats[folder1] = make(map[string]float64)
+				}
+				diskStats[folder1]["diskfree"] = diskfree1
+				diskStats[folder1]["sizePercent"] = sizePercent1
+			}		
 
 		} else {
 			folderMatch := r.SubexpIndex("folder")
@@ -440,6 +457,9 @@ func findObject(line string) (match []string, r *regexp.Regexp, matchType string
 			sizeusedMatch := r.SubexpIndex("sizeused")
 			sizelimitMatch := r.SubexpIndex("sizelimit")
 			diskfreeMatch := r.SubexpIndex("diskfree")
+			sizelimitunitMatch := r.SubexpIndex("sizelimitunit")
+			sizeunitMatch := r.SubexpIndex("sizeunit")
+			freeunitMatch := r.SubexpIndex("freeunit")
 
 			folder := match[folderMatch]
 			hoursused, err := convertStrFloat(match[hoursusedMatch])
@@ -452,32 +472,51 @@ func findObject(line string) (match []string, r *regexp.Regexp, matchType string
 				common.BIlogger(fmt.Sprintf("Unable to convert hourstotal string to float: \n%v", hourstotal), "console")
 				return nil, nil, ""
 			}
-			sizeused, err := convertBytes(match[sizeusedMatch])
-			if err != nil {
-				common.BIlogger(fmt.Sprintf("Unable to get convert sizeused Error: \n%v", err), "console")
-				return nil, nil, ""
-			}
-			sizelimit, err := convertBytes(match[sizelimitMatch])
+			sizelimit, err := convertBytes(match[sizelimitMatch],match[sizelimitunitMatch])
 			if err != nil {
 				common.BIlogger(fmt.Sprintf("Unable to get convert sizelimit Error: \n%v", err), "console")
 				return nil, nil, ""
 			}
-			diskfree, err := convertBytes(match[diskfreeMatch])
+			diskfree, err := convertBytes(match[diskfreeMatch],match[freeunitMatch])
 			if err != nil {
 				common.BIlogger(fmt.Sprintf("Unable to get convert diskfree Error: \n%v", err), "console")
 				return nil, nil, ""
 			}
 
 			hourPercent := (hoursused / hourstotal) * 100
-			sizePercent := (sizeused / sizelimit) * 100
 
-			if _, ok := diskStats[folder]; !ok {
-				diskStats[folder] = make(map[string]float64)
+
+			if strings.Compare(match[sizeunitMatch],"") == 0 {
+				sizeused, err := convertBytes(match[sizeusedMatch],match[sizelimitunitMatch])
+				if err != nil {
+					common.BIlogger(fmt.Sprintf("Unable to get convert sizeused Error: \n%v", err), "console")
+					return nil, nil, ""
+				}
+				sizePercent := (sizeused / sizelimit) * 100
+
+				if _, ok := diskStats[folder]; !ok {
+					diskStats[folder] = make(map[string]float64)
+				}
+	
+				diskStats[folder]["diskfree"] = diskfree
+				diskStats[folder]["hourPercent"] = hourPercent
+				diskStats[folder]["sizePercent"] = sizePercent
+			} else {
+				sizeused, err := convertBytes(match[sizeusedMatch], match[sizeunitMatch])
+				if err != nil {
+					common.BIlogger(fmt.Sprintf("Unable to get convert sizeused Error: \n%v", err), "console")
+					return nil, nil, ""
+				}
+				sizePercent := (sizeused / sizelimit) * 100
+
+				if _, ok := diskStats[folder]; !ok {
+					diskStats[folder] = make(map[string]float64)
+				}
+	
+				diskStats[folder]["diskfree"] = diskfree
+				diskStats[folder]["hourPercent"] = hourPercent
+				diskStats[folder]["sizePercent"] = sizePercent
 			}
-
-			diskStats[folder]["diskfree"] = diskfree
-			diskStats[folder]["hourPercent"] = hourPercent
-			diskStats[folder]["sizePercent"] = sizePercent
 		}
 
 	} else if strings.HasPrefix(line, "2") {

--- a/metrics.go
+++ b/metrics.go
@@ -21,7 +21,7 @@ var (
 	namespace string = "blueiris"
 
 	blueIrisServerMetrics = metrics{
-		1:  newMetric("ai_duration", "Duration of Blue Iris AI analysis", prometheus.GaugeValue, []string{"camera", "type", "object", "detail"}, blueiris.BlueIris, CollectBool{true: []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}}, "blueIrisServerMetrics"),
+		1:  newMetric("ai_duration", "Duration of Blue Iris AI analysis", prometheus.GaugeValue, []string{"camera", "type", "object", "detail"}, blueiris.BlueIris, CollectBool{true: []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22}}, "blueIrisServerMetrics"),
 		2:  newMetric("ai_count", "Count of Blue Iris AI analysis", prometheus.GaugeValue, []string{"camera", "type"}, blueiris.BlueIris, CollectBool{false: nil}, "blueIrisServerMetrics"),
 		3:  newMetric("ai_duration_distinct", "Duration of Blue Iris AI analysis once", prometheus.GaugeValue, []string{"camera", "type", "object", "detail"}, blueiris.BlueIris, CollectBool{false: nil}, "blueIrisServerMetrics"),
 		4:  newMetric("ai_restarted", "Times BlueIris restarted Deepstack", prometheus.GaugeValue, []string{}, blueiris.BlueIris, CollectBool{false: nil}, "blueIrisServerMetrics"),
@@ -42,6 +42,7 @@ var (
 		19: newMetric("parse_errors_total", "Count of all the errors parsing log lines", prometheus.GaugeValue, []string{}, blueiris.BlueIris, CollectBool{false: nil}, "blueIrisServerMetrics"),
 		20: newMetric("ai_starting", "Count of AI is being started log lines", prometheus.GaugeValue, []string{}, blueiris.BlueIris, CollectBool{false: nil}, "blueIrisServerMetrics"),
 		21: newMetric("ai_started", "Count of AI has been started log lines", prometheus.GaugeValue, []string{}, blueiris.BlueIris, CollectBool{false: nil}, "blueIrisServerMetrics"),
+		22: newMetric("profile", "Count of activation of profiles", prometheus.GaugeValue, []string{"profile"}, blueiris.BlueIris, CollectBool{false: nil}, "blueIrisServerMetrics"),
 	}
 
 	scrapeDurationDesc = prometheus.NewDesc(


### PR DESCRIPTION
Hi,
I have developped a feature to monitor the active profile of BlueIris. It can be used in grafana with this example of visualization.
![Capture d'écran 2024-02-22 154324](https://github.com/wymangr/blueiris_exporter/assets/38831521/e9d00c4c-aea7-46a6-9eee-cdd8a5d53c01)

Moreover, I have updated the way the code handle the bytes units because blueiris logs have changed with the newest version 
old version:
`[300/432 hrs, 3.63T/3.63T, 5.33G free]`

New version:
`[240/336 hrs, 459.4/460.0GB, 6.17GB free]`

As there is no more the unit in the used storage and as there is also the GB vs G, I have extracted units and passed it as an argument to the function ConvertBytes.
It works with a log that has got both formats.

Hope these pieces of code can be included in the code :)